### PR TITLE
Pin spatie/ssl-certificate dependency to 1.21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "acquia/acsf-contenthub-console": "dev-main",
         "ext-json": "*",
-        "spatie/ssl-certificate": "^1.19"
+        "spatie/ssl-certificate": "1.21"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Version 1.21 is the latest to still support php 7.3